### PR TITLE
Add python2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:vivid
 
-RUN apt-get -q update
-RUN apt-get install --yes -q \
+RUN apt-get -q update \
+    && apt-get install --yes -q \
     git \
     mercurial \
     python-dev \
@@ -20,8 +20,8 @@ RUN apt-get install --yes -q \
     && apt-get clean
 
 RUN add-apt-repository --yes ppa:fkrull/deadsnakes
-RUN apt-get -q update
-RUN apt-get install --yes -q \
+RUN apt-get -q update \\
+    && apt-get install --yes -q \
     python2.6 \
     python2.6-dev \
     && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN add-apt-repository --yes ppa:fkrull/deadsnakes
 RUN apt-get -q update
 RUN apt-get install --yes -q \
     python2.6 \
-    python2.6-dev
+    python2.6-dev \
+    && apt-get clean
 
+# Ubuntu's virtualenv.py uses same new-style formatting that Python 2.6 doesn't support.
+# We need to revert that for Python 2.6 to function correctly with it.
 RUN sed -i -e 's,{}-\*.whl,{0}-*.whl,' /usr/lib/python3/dist-packages/virtualenv.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,13 @@ RUN apt-get install --yes -q \
     libmysqlclient-dev \
     curl \
     wget \
+    software-properties-common \
     && apt-get clean
+
+RUN add-apt-repository --yes ppa:fkrull/deadsnakes
+RUN apt-get -q update
+RUN apt-get install --yes -q \
+    python2.6 \
+    python2.6-dev
+
+RUN sed -i -e 's,{}-\*.whl,{0}-*.whl,' /usr/lib/python3/dist-packages/virtualenv.py


### PR DESCRIPTION
This adds python2.6 from the deadsnakes PPA, and hacks the installed virtualenv.py to work with Python 2.6. I used it successfully in this test run: https://tools.taskcluster.net/task-inspector/#B0t74CReSE2G7ek38pW2GA/0

Is it too terrible to accept? :)