### PR TITLE
Specify Python 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get -q update \
     git \
     mercurial \
     python-dev \
-    python3-dev \
+    python3.5-dev \
     python-tox \
     pypy \
     python-pip \


### PR DESCRIPTION
Since we don't seem to be using earlier Python 3 versions, and 3.5 is not the default, make sure 3.5 is installed.